### PR TITLE
if role is tool then set to user

### DIFF
--- a/app/services/chat/message_converter.py
+++ b/app/services/chat/message_converter.py
@@ -36,10 +36,17 @@ class OpenAIMessageConverter(MessageConverter):
         converted_messages = []
         system_instruction = None
 
-        for msg in messages:
+        for idx, msg in enumerate(messages):
             role = msg.get("role", "")
             if role not in SUPPORTED_ROLES:
-                role = "model"
+                if role == "tool":
+                    role = "user"
+                else:
+                    # 如果是最后一条消息，则认为是用户消息
+                    if idx == len(messages) - 1:
+                        role = "user"
+                    else:
+                        role = "model"
 
             parts = []
             if isinstance(msg["content"], str) and msg["content"]:

--- a/app/services/openai_chat_service.py
+++ b/app/services/openai_chat_service.py
@@ -57,7 +57,14 @@ def _build_tools(
                 function_declarations.append(function)
 
         if function_declarations:
-            tools.append({"functionDeclarations": function_declarations})
+            # 按照 function 的 name 去重
+            names, functions = set(), []
+            for item in function_declarations:
+                if item.get("name") not in names:
+                    names.add(item.get("name"))
+                    functions.append(item)
+
+            tools.append({"functionDeclarations": functions})
             
     return tools
 


### PR DESCRIPTION
> 背景：使用function call时，**最后一条**消息通常**来自于调用结果**，在消息转换过程中role会**被修改为`model`**，从而导致模型不返回任何内容

+ 如果消息的role不是user、model或者system：
  + 如果role为tool或者是最后一条消息，则设置为user
  + 否则设置为model

+ 按照function的name对请求中tools里的functionDeclarations去重