### PR TITLE
feat: 支持mysql socket连接

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # MySQL数据库配置
 MYSQL_HOST=gemini-balance-mysql
+#MYSQL_SOCKET=/run/mysqld/mysqld.sock
 MYSQL_PORT=3306
 MYSQL_USER=gemini
 MYSQL_PASSWORD=change_me

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ app/
 | :--------------------------- | :------------------------------------------------------- | :---------------------------------------------------- |
 | **数据库配置**               |                                                          |                                                       |
 | `MYSQL_HOST`                 | 必填，MySQL 数据库主机地址                               | `localhost`                                           |
+| `MYSQL_SOCKET`               | 可选，MySQL 数据库 socket 地址                             | `/var/run/mysqld/mysqld.sock`                          |
 | `MYSQL_PORT`                 | 必填，MySQL 数据库端口                                   | `3306`                                                |
 | `MYSQL_USER`                 | 必填，MySQL 数据库用户名                                 | `your_db_user`                                        |
 | `MYSQL_PASSWORD`             | 必填，MySQL 数据库密码                                   | `your_db_password`                                    |

--- a/app/config/config.py
+++ b/app/config/config.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
     MYSQL_USER: str
     MYSQL_PASSWORD: str
     MYSQL_DATABASE: str
+    MYSQL_SOCKET: str = None
     
     # API相关配置
     API_KEYS: List[str]

--- a/app/database/connection.py
+++ b/app/database/connection.py
@@ -12,7 +12,10 @@ from app.log.logger import get_database_logger
 logger = get_database_logger()
 
 # 数据库URL
-DATABASE_URL = f"mysql+pymysql://{settings.MYSQL_USER}:{settings.MYSQL_PASSWORD}@{settings.MYSQL_HOST}:{settings.MYSQL_PORT}/{settings.MYSQL_DATABASE}"
+if settings.MYSQL_SOCKET:
+    DATABASE_URL = f"mysql+pymysql://{settings.MYSQL_USER}:{settings.MYSQL_PASSWORD}@/{settings.MYSQL_DATABASE}?unix_socket={settings.MYSQL_SOCKET}"
+else:
+    DATABASE_URL = f"mysql+pymysql://{settings.MYSQL_USER}:{settings.MYSQL_PASSWORD}@{settings.MYSQL_HOST}:{settings.MYSQL_PORT}/{settings.MYSQL_DATABASE}"
 
 # 创建数据库引擎
 # pool_pre_ping=True: 在从连接池获取连接前执行简单的 "ping" 测试，确保连接有效


### PR DESCRIPTION
对于宿主机已经安装MySQL数据库的情况，可以通过挂载.sock文件实现数据库的连接和MySQL服务的复用

```docker-compose
services:
  gemini-balance:
    image: gemini-balance
    container_name: gemini-balance
    restart: unless-stopped
    volumes:
      - /run/mysqld/mysqld.sock:/run/mysqld/mysqld.sock
    ports:
      - "8000:8000"
    env_file:
      - .env
    healthcheck:
      test: ["CMD-SHELL", "python -c \"import requests; exit(0) if requests.get('http://localhost:8000/health').status_code == 200 else exit(1)\""]
      interval: 30s
      timeout: 5s
      retries: 3
      start_period: 10s
```