### PR TITLE
支持 SQLite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
-# MySQL数据库配置
+# 数据库配置
+DATABASE_TYPE=mysql
+#SQLITE_DATABASE=default_db
 MYSQL_HOST=gemini-balance-mysql
 #MYSQL_SOCKET=/run/mysqld/mysqld.sock
 MYSQL_PORT=3306

--- a/README.md
+++ b/README.md
@@ -143,12 +143,14 @@ app/
 | 配置项                       | 说明                                                     | 默认值                             |
 | :--------------------------- | :------------------------------------------------------- | :---------------------------------------------------- |
 | **数据库配置**               |                                                          |                                                       |
-| `MYSQL_HOST`                 | 必填，MySQL 数据库主机地址                               | `localhost`                                           |
-| `MYSQL_SOCKET`               | 可选，MySQL 数据库 socket 地址                             | `/var/run/mysqld/mysqld.sock`                          |
-| `MYSQL_PORT`                 | 必填，MySQL 数据库端口                                   | `3306`                                                |
-| `MYSQL_USER`                 | 必填，MySQL 数据库用户名                                 | `your_db_user`                                        |
-| `MYSQL_PASSWORD`             | 必填，MySQL 数据库密码                                   | `your_db_password`                                    |
-| `MYSQL_DATABASE`             | 必填，MySQL 数据库名称                                   | `defaultdb`                                   |
+| `DATABASE_TYPE`              | 可选，数据库类型，支持 `mysql` 或 `sqlite`               | `mysql`                                              |
+| `SQLITE_DATABASE`            | 可选，当使用 `sqlite` 时必填，SQLite 数据库文件路径 | `default_db`                                         |
+| `MYSQL_HOST`                 | 当使用 `mysql` 时必填，MySQL 数据库主机地址    | `localhost`                                          |
+| `MYSQL_SOCKET`               | 可选，MySQL 数据库 socket 地址                          | `/var/run/mysqld/mysqld.sock`                        |
+| `MYSQL_PORT`                 | 当使用 `mysql` 时必填，MySQL 数据库端口        | `3306`                                               |
+| `MYSQL_USER`                 | 当使用 `mysql` 时必填，MySQL 数据库用户名      | `your_db_user`                                       |
+| `MYSQL_PASSWORD`             | 当使用 `mysql` 时必填，MySQL 数据库密码        | `your_db_password`                                   |
+| `MYSQL_DATABASE`             | 当使用 `mysql` 时必填，MySQL 数据库名称        | `defaultdb`                                          |
 | **API 相关配置**             |                                                          |                                                       |
 | `API_KEYS`                   | 必填，Gemini API 密钥列表，用于负载均衡                        | `["your-gemini-api-key-1", "your-gemini-api-key-2"]`  |
 | `ALLOWED_TOKENS`             | 必填，允许访问的 Token 列表                                    | `["your-access-token-1", "your-access-token-2"]`      |

--- a/app/config/config.py
+++ b/app/config/config.py
@@ -5,7 +5,7 @@ import datetime
 import json
 from typing import List, Any, Dict, Type
 
-from pydantic import ValidationError
+from pydantic import ValidationError, validator
 from pydantic_settings import BaseSettings
 from sqlalchemy import insert, update, select
 
@@ -15,13 +15,23 @@ from app.log.logger import Logger
 
 class Settings(BaseSettings):
     # 数据库配置
-    MYSQL_HOST: str
-    MYSQL_PORT: int
-    MYSQL_USER: str
-    MYSQL_PASSWORD: str
-    MYSQL_DATABASE: str
+    DATABASE_TYPE: str = "mysql"  # sqlite 或 mysql
+    SQLITE_DATABASE: str = "default_db"
+    MYSQL_HOST: str = ""
+    MYSQL_PORT: int = 3306
+    MYSQL_USER: str = ""
+    MYSQL_PASSWORD: str = ""
+    MYSQL_DATABASE: str = ""
     MYSQL_SOCKET: str = ""
     
+    # 验证 MySQL 配置
+    @validator('MYSQL_HOST', 'MYSQL_PORT', 'MYSQL_USER', 'MYSQL_PASSWORD', 'MYSQL_DATABASE')
+    def validate_mysql_config(cls, v, values):
+        if values.get('DATABASE_TYPE') == 'mysql':
+            if v is None or v == "":
+                raise ValueError(f"MySQL configuration is required when DATABASE_TYPE is 'mysql'")
+        return v
+
     # API相关配置
     API_KEYS: List[str]
     ALLOWED_TOKENS: List[str]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ cryptography # 支持 MySQL 8+ caching_sha2_password 验证
 pymysql
 sqlalchemy
 aiomysql
+aiosqlite
 databases
 python-dotenv
 apscheduler


### PR DESCRIPTION
Fixed #91 
- 在 `.env.example` 文件中添加了 `DATABASE_TYPE` 变量，用于指定数据库类型，默认使用 mysql
- 添加了 `DATABASE_TYPE` 和 `SQLITE_DATABASE` 配置项
- 在使用 mysql 时，对其他 MySQL 配置进行验证
- 添加 `aiosqlite` 依赖