### PR TITLE
fix: 修复请求日志删除任务中的时区属性错误

### DIFF
--- a/app/service/request_log/request_log_service.py
+++ b/app/service/request_log/request_log_service.py
@@ -2,7 +2,7 @@
 Service for request log operations.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import delete
 
@@ -30,7 +30,7 @@ async def delete_old_request_logs_task():
     )
 
     try:
-        cutoff_date = datetime.now(datetime.timezone.utc) - timedelta(days=days_to_keep)
+        cutoff_date = datetime.now(timezone.utc) - timedelta(days=days_to_keep)
 
         query = delete(RequestLog).where(RequestLog.request_time < cutoff_date)
 


### PR DESCRIPTION

将获取当前 UTC 时间的方式从 `datetime.now(datetime.timezone.utc)` 修改为 `datetime.now(timezone.utc)`。

错误日志

```
2025-05-11 03:05:00,003 | INFO     | [request_log_service.py:28]    | Starting scheduled task to delete old request logs older than 30 days.
2025-05-11 03:05:00,003 | ERROR    | [request_log_service.py:47]    | An error occurred during the scheduled request log deletion: type object 'datetime.datetime' has no attribute 'timezone'
Traceback (most recent call last):
  File "/app/app/service/request_log/request_log_service.py", line 33, in delete_old_request_logs_task
    cutoff_date = datetime.now(datetime.timezone.utc) - timedelta(days=days_to_keep)
AttributeError: type object 'datetime.datetime' has no attribute 'timezone'. Did you mean: 'astimezone'?
```