### PR TITLE
feat: 在OpenAI chat服务中，适配googleSearch内置工具调用

### DIFF
--- a/app/service/chat/openai_chat_service.py
+++ b/app/service/chat/openai_chat_service.py
@@ -83,8 +83,13 @@ def _build_tools(
             names, functions = set(), []
             for fc in function_declarations:
                 if fc.get("name") not in names:
-                    names.add(fc.get("name"))
-                    functions.append(fc)
+                    if fc.get("name")=="googleSearch":
+                        # cherry开启内置搜索时，添加googleSearch工具
+                        tool["googleSearch"] = {}
+                    else:
+                        # 其他函数，添加到functionDeclarations中
+                        names.add(fc.get("name"))
+                        functions.append(fc)
 
             tool["functionDeclarations"] = functions
 


### PR DESCRIPTION
问题：openai_chat_service，在CherryStudio开启内置搜索时，googleSearch被拼接到functionDeclarations中，导致gemini内置搜索失效。
修改后，不带-search的模型可通过开启“模型内置搜索”调用googleSearch

