### PR TITLE
Fix: 修复使用 docker 运行时环境变量的错误解析

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,4 +71,4 @@ FAKE_STREAM_EMPTY_DATA_INTERVAL_SECONDS=5
 
 # 安全设置 (JSON 字符串格式)
 # 注意：这里的示例值可能需要根据实际模型支持情况调整
-SAFETY_SETTINGS='[{"category": "HARM_CATEGORY_HARASSMENT", "threshold": "OFF"}, {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "OFF"}, {"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "OFF"}, {"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "OFF"}, {"category": "HARM_CATEGORY_CIVIC_INTEGRITY", "threshold": "BLOCK_NONE"}]'
+SAFETY_SETTINGS=[{"category": "HARM_CATEGORY_HARASSMENT", "threshold": "OFF"}, {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "OFF"}, {"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "OFF"}, {"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "OFF"}, {"category": "HARM_CATEGORY_CIVIC_INTEGRITY", "threshold": "BLOCK_NONE"}]

--- a/.env.example
+++ b/.env.example
@@ -64,8 +64,10 @@ AUTO_DELETE_REQUEST_LOGS_DAYS=30
 ##########################################################################
 
 # 假流式配置 (Fake Streaming Configuration)
-FAKE_STREAM_ENABLED=True  # 是否启用假流式输出
-FAKE_STREAM_EMPTY_DATA_INTERVAL_SECONDS=5  # 假流式发送空数据的间隔时间（秒）
+# 是否启用假流式输出
+FAKE_STREAM_ENABLED=True
+# 假流式发送空数据的间隔时间（秒）
+FAKE_STREAM_EMPTY_DATA_INTERVAL_SECONDS=5
 
 # 安全设置 (JSON 字符串格式)
 # 注意：这里的示例值可能需要根据实际模型支持情况调整


### PR DESCRIPTION
- 调整了注释的位置，因为 [docker 解析](https://docs.docker.com/reference/cli/docker/container/run/#env)时会把行内的 `#` 当成值的一部分
![image](https://github.com/user-attachments/assets/9027854a-d956-4abc-b82a-fc91eadcacf1)
- 删除 `SAFETY_SETTINGS` 两边的引号以防止被错误解析 Fixed #95