### PR TITLE
feat: 增加了代理列表使用策略选项，对于同一个API_KEY可以使用固定代理

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,8 @@ TIME_OUT=300
 # 代理服务器配置 (支持 http 和 socks5)
 # 示例: PROXIES=["http://user:pass@host:port", "socks5://host:port"]
 PROXIES=[]
+# 对同一个API_KEY使用代理列表中固定的IP策略
+PROXIES_USE_CONSISTENCY_HASH_BY_API_KEY=true
 #########################image_generate 相关配置###########################
 PAID_KEY=AIzaSyxxxxxxxxxxxxxxxxxxx
 CREATE_IMAGE_MODEL=imagen-3.0-generate-002

--- a/app/config/config.py
+++ b/app/config/config.py
@@ -60,6 +60,7 @@ class Settings(BaseSettings):
     TIME_OUT: int = DEFAULT_TIMEOUT
     MAX_RETRIES: int = MAX_RETRIES
     PROXIES: List[str] = []
+    PROXIES_USE_CONSISTENCY_HASH_BY_API_KEY: bool = True  # 是否使用一致性哈希来选择代理
     VERTEX_API_KEYS: List[str] = []
     VERTEX_EXPRESS_BASE_URL: str = "https://aiplatform.googleapis.com/v1beta1/publishers/google"
  

--- a/app/service/client/api_client.py
+++ b/app/service/client/api_client.py
@@ -46,7 +46,10 @@ class GeminiApiClient(ApiClient):
         
         proxy_to_use = None
         if settings.PROXIES:
-            proxy_to_use = random.choice(settings.PROXIES)
+            if settings.PROXIES_USE_CONSISTENCY_HASH_BY_API_KEY:
+                proxy_to_use = settings.PROXIES[hash(api_key) % len(settings.PROXIES)]
+            else:
+                proxy_to_use = random.choice(settings.PROXIES)
             logger.info(f"Using proxy for getting models: {proxy_to_use}")
 
         async with httpx.AsyncClient(timeout=timeout, proxy=proxy_to_use) as client:
@@ -69,8 +72,11 @@ class GeminiApiClient(ApiClient):
 
         proxy_to_use = None
         if settings.PROXIES:
-            proxy_to_use = random.choice(settings.PROXIES)
-            logger.info(f"Using proxy: {proxy_to_use}")
+            if settings.PROXIES_USE_CONSISTENCY_HASH_BY_API_KEY:
+                proxy_to_use = settings.PROXIES[hash(api_key) % len(settings.PROXIES)]
+            else:
+                proxy_to_use = random.choice(settings.PROXIES)
+            logger.info(f"Using proxy for getting models: {proxy_to_use}")
             
         async with httpx.AsyncClient(timeout=timeout, proxy=proxy_to_use) as client:
             url = f"{self.base_url}/models/{model}:generateContent?key={api_key}"
@@ -86,8 +92,11 @@ class GeminiApiClient(ApiClient):
         
         proxy_to_use = None
         if settings.PROXIES:
-            proxy_to_use = random.choice(settings.PROXIES)
-            logger.info(f"Using proxy: {proxy_to_use}")
+            if settings.PROXIES_USE_CONSISTENCY_HASH_BY_API_KEY:
+                proxy_to_use = settings.PROXIES[hash(api_key) % len(settings.PROXIES)]
+            else:
+                proxy_to_use = random.choice(settings.PROXIES)
+            logger.info(f"Using proxy for getting models: {proxy_to_use}")
 
         async with httpx.AsyncClient(timeout=timeout, proxy=proxy_to_use) as client:
             url = f"{self.base_url}/models/{model}:streamGenerateContent?alt=sse&key={api_key}"
@@ -109,7 +118,16 @@ class OpenaiApiClient(ApiClient):
         
     async def get_models(self, api_key: str) -> Dict[str, Any]:
         timeout = httpx.Timeout(self.timeout, read=self.timeout)
-        async with httpx.AsyncClient(timeout=timeout) as client:
+
+        proxy_to_use = None
+        if settings.PROXIES:
+            if settings.PROXIES_USE_CONSISTENCY_HASH_BY_API_KEY:
+                proxy_to_use = settings.PROXIES[hash(api_key) % len(settings.PROXIES)]
+            else:
+                proxy_to_use = random.choice(settings.PROXIES)
+            logger.info(f"Using proxy for getting models: {proxy_to_use}")
+
+        async with httpx.AsyncClient(timeout=timeout, proxy=proxy_to_use) as client:
             url = f"{self.base_url}/openai/models"
             headers = {"Authorization": f"Bearer {api_key}"}
             response = await client.get(url, headers=headers)
@@ -120,11 +138,14 @@ class OpenaiApiClient(ApiClient):
 
     async def generate_content(self, payload: Dict[str, Any], api_key: str) -> Dict[str, Any]:
         timeout = httpx.Timeout(self.timeout, read=self.timeout)
-        
+        logger.info(f"settings.PROXIES_USE_CONSISTENCY_HASH_BY_API_KEY: {settings.PROXIES_USE_CONSISTENCY_HASH_BY_API_KEY}")
         proxy_to_use = None
         if settings.PROXIES:
-            proxy_to_use = random.choice(settings.PROXIES)
-            logger.info(f"Using proxy: {proxy_to_use}")
+            if settings.PROXIES_USE_CONSISTENCY_HASH_BY_API_KEY:
+                proxy_to_use = settings.PROXIES[hash(api_key) % len(settings.PROXIES)]
+            else:
+                proxy_to_use = random.choice(settings.PROXIES)
+            logger.info(f"Using proxy for getting models: {proxy_to_use}")
 
         async with httpx.AsyncClient(timeout=timeout, proxy=proxy_to_use) as client:
             url = f"{self.base_url}/openai/chat/completions"
@@ -137,11 +158,13 @@ class OpenaiApiClient(ApiClient):
 
     async def stream_generate_content(self, payload: Dict[str, Any], api_key: str) -> AsyncGenerator[str, None]:
         timeout = httpx.Timeout(self.timeout, read=self.timeout)
-        
         proxy_to_use = None
         if settings.PROXIES:
-            proxy_to_use = random.choice(settings.PROXIES)
-            logger.info(f"Using proxy: {proxy_to_use}")
+            if settings.PROXIES_USE_CONSISTENCY_HASH_BY_API_KEY:
+                proxy_to_use = settings.PROXIES[hash(api_key) % len(settings.PROXIES)]
+            else:
+                proxy_to_use = random.choice(settings.PROXIES)
+            logger.info(f"Using proxy for getting models: {proxy_to_use}")
 
         async with httpx.AsyncClient(timeout=timeout, proxy=proxy_to_use) as client:
             url = f"{self.base_url}/openai/chat/completions"
@@ -159,8 +182,11 @@ class OpenaiApiClient(ApiClient):
         
         proxy_to_use = None
         if settings.PROXIES:
-            proxy_to_use = random.choice(settings.PROXIES)
-            logger.info(f"Using proxy: {proxy_to_use}")
+            if settings.PROXIES_USE_CONSISTENCY_HASH_BY_API_KEY:
+                proxy_to_use = settings.PROXIES[hash(api_key) % len(settings.PROXIES)]
+            else:
+                proxy_to_use = random.choice(settings.PROXIES)
+            logger.info(f"Using proxy for getting models: {proxy_to_use}")
 
         async with httpx.AsyncClient(timeout=timeout, proxy=proxy_to_use) as client:
             url = f"{self.base_url}/openai/embeddings"
@@ -177,11 +203,14 @@ class OpenaiApiClient(ApiClient):
                     
     async def generate_images(self, payload: Dict[str, Any], api_key: str) -> Dict[str, Any]:
         timeout = httpx.Timeout(self.timeout, read=self.timeout)
-        
+
         proxy_to_use = None
         if settings.PROXIES:
-            proxy_to_use = random.choice(settings.PROXIES)
-            logger.info(f"Using proxy: {proxy_to_use}")
+            if settings.PROXIES_USE_CONSISTENCY_HASH_BY_API_KEY:
+                proxy_to_use = settings.PROXIES[hash(api_key) % len(settings.PROXIES)]
+            else:
+                proxy_to_use = random.choice(settings.PROXIES)
+            logger.info(f"Using proxy for getting models: {proxy_to_use}")
 
         async with httpx.AsyncClient(timeout=timeout, proxy=proxy_to_use) as client:
             url = f"{self.base_url}/openai/images/generations"

--- a/app/templates/config_editor.html
+++ b/app/templates/config_editor.html
@@ -1021,6 +1021,33 @@ endblock %} {% block head_extra_styles %}
             socks5://host:port。点击按钮可批量添加或删除。</small
           >
         </div>
+        <!-- 代理使用策略 -->
+        <div class="mb-6">
+          <div class="flex items-center justify-between">
+              <label
+                      for="PROXIES_USE_CONSISTENCY_HASH_BY_API_KEY"
+                      class="font-semibold text-gray-700"
+              >是否开启固定代理策略</label
+              >
+              <div
+                      class="relative inline-block w-10 mr-2 align-middle select-none transition duration-200 ease-in"
+              >
+                  <input
+                          type="checkbox"
+                          name="PROXIES_USE_CONSISTENCY_HASH_BY_API_KEY"
+                          id="PROXIES_USE_CONSISTENCY_HASH_BY_API_KEY"
+                          class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"
+                  />
+                  <label
+                          for="PROXIES_USE_CONSISTENCY_HASH_BY_API_KEY"
+                          class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"
+                  ></label>
+              </div>
+          </div>
+          <small class="text-gray-500 mt-1 block"
+          >开启后，对于每一个API_KEY将根据算法从代理列表中选取同一个代理IP，防止一个API_KEY同时被多个IP访问，也同时防止了一个IP访问了过多的API_KEY。</small
+          >
+        </div>
       </div>
 
       <!-- 模型相关配置 -->


### PR DESCRIPTION
![CleanShot 2025-06-14 at 14 41 35](https://github.com/user-attachments/assets/c1e31d23-b74a-43c8-8bc1-0ac3e668a640)

对于每一个API_KEY将根据算法从代理列表中选取同一个代理IP，防止一个API_KEY同时被多个IP访问，也同时防止了一个IP访问了过多的API_KEY。
环境变量增加PROXIES_USE_CONSISTENCY_HASH_BY_API_KEY=true