### PR TITLE
fix: 修复api中对role的校验

### DIFF
--- a/app/domain/gemini_models.py
+++ b/app/domain/gemini_models.py
@@ -44,12 +44,12 @@ class GenerationConfig(BaseModel):
 
 
 class SystemInstruction(BaseModel):
-    role: str = "system"
+    role: Optional[str] = "system"
     parts: Union[List[Dict[str, Any]], Dict[str, Any]]
 
 
 class GeminiContent(BaseModel):
-    role: str
+    role: Optional[str] = None
     parts: List[Dict[str, Any]]
 
 


### PR DESCRIPTION
下面的官方给的调用示例，无法通过服务的参数校验。


```bash
curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent" \
  -H 'Content-Type: application/json' \
  -H 'X-goog-api-key: GEMINI_API_KEY' \
  -X POST \
  -d '{
    "contents": [
      {
        "parts": [
          {
            "text": "Explain how AI works in a few words"
          }
        ]
      }
    ]
  }'
```

修复方式是去掉对role的校验