### PR TITLE
修复与Claude Code Router兼容性问题：清理不支持的JSON Schema字段和generationConfig处理

### DIFF
--- a/app/service/chat/gemini_chat_service.py
+++ b/app/service/chat/gemini_chat_service.py
@@ -28,6 +28,33 @@ def _has_image_parts(contents: List[Dict[str, Any]]) -> bool:
     return False
 
 
+def _clean_json_schema_properties(obj: Any) -> Any:
+    """清理JSON Schema中Gemini API不支持的字段"""
+    if not isinstance(obj, dict):
+        return obj
+    
+    # Gemini API不支持的JSON Schema字段
+    unsupported_fields = {
+        "exclusiveMaximum", "exclusiveMinimum", "const", "examples", 
+        "contentEncoding", "contentMediaType", "if", "then", "else",
+        "allOf", "anyOf", "oneOf", "not", "definitions", "$schema",
+        "$id", "$ref", "$comment", "readOnly", "writeOnly"
+    }
+    
+    cleaned = {}
+    for key, value in obj.items():
+        if key in unsupported_fields:
+            continue
+        if isinstance(value, dict):
+            cleaned[key] = _clean_json_schema_properties(value)
+        elif isinstance(value, list):
+            cleaned[key] = [_clean_json_schema_properties(item) for item in value]
+        else:
+            cleaned[key] = value
+    
+    return cleaned
+
+
 def _build_tools(model: str, payload: Dict[str, Any]) -> List[Dict[str, Any]]:
     """构建工具"""
     
@@ -40,7 +67,15 @@ def _build_tools(model: str, payload: Dict[str, Any]) -> List[Dict[str, Any]]:
             for k, v in item.items():
                 if k == "functionDeclarations" and v and isinstance(v, list):
                     functions = record.get("functionDeclarations", [])
-                    functions.extend(v)
+                    # 清理每个函数声明中的不支持字段
+                    cleaned_functions = []
+                    for func in v:
+                        if isinstance(func, dict):
+                            cleaned_func = _clean_json_schema_properties(func)
+                            cleaned_functions.append(cleaned_func)
+                        else:
+                            cleaned_functions.append(func)
+                    functions.extend(cleaned_functions)
                     record["functionDeclarations"] = functions
                 else:
                     record[k] = v

--- a/app/service/chat/gemini_chat_service.py
+++ b/app/service/chat/gemini_chat_service.py
@@ -114,6 +114,10 @@ def _build_payload(model: str, request: GeminiRequest) -> Dict[str, Any]:
         "systemInstruction": request_dict.get("systemInstruction"),
     }
 
+    # 确保 generationConfig 不为 None
+    if payload["generationConfig"] is None:
+        payload["generationConfig"] = {}
+
     if model.endswith("-image") or model.endswith("-image-generation"):
         payload.pop("systemInstruction")
         payload["generationConfig"]["responseModalities"] = ["Text", "Image"]

--- a/app/service/chat/openai_chat_service.py
+++ b/app/service/chat/openai_chat_service.py
@@ -26,14 +26,41 @@ from app.service.key.key_manager import KeyManager
 logger = get_openai_logger()
 
 
-def _has_media_parts(contents: List[Dict[str, Any]]) -> bool:
-    """判断消息是否包含图片、音频或视频部分 (inline_data)"""
-    for content in contents:
-        if content and "parts" in content and isinstance(content["parts"], list):
-            for part in content["parts"]:
-                if isinstance(part, dict) and "inline_data" in part:
+def _has_media_parts(messages: List[Dict[str, Any]]) -> bool:
+    """判断消息是否包含多媒体部分"""
+    for message in messages:
+        if "parts" in message:
+            for part in message["parts"]:
+                if "image_url" in part or "inline_data" in part:
                     return True
     return False
+
+
+def _clean_json_schema_properties(obj: Any) -> Any:
+    """清理JSON Schema中Gemini API不支持的字段"""
+    if not isinstance(obj, dict):
+        return obj
+    
+    # Gemini API不支持的JSON Schema字段
+    unsupported_fields = {
+        "exclusiveMaximum", "exclusiveMinimum", "const", "examples", 
+        "contentEncoding", "contentMediaType", "if", "then", "else",
+        "allOf", "anyOf", "oneOf", "not", "definitions", "$schema",
+        "$id", "$ref", "$comment", "readOnly", "writeOnly"
+    }
+    
+    cleaned = {}
+    for key, value in obj.items():
+        if key in unsupported_fields:
+            continue
+        if isinstance(value, dict):
+            cleaned[key] = _clean_json_schema_properties(value)
+        elif isinstance(value, list):
+            cleaned[key] = [_clean_json_schema_properties(item) for item in value]
+        else:
+            cleaned[key] = value
+    
+    return cleaned
 
 
 def _build_tools(
@@ -76,6 +103,8 @@ def _build_tools(
                 ):
                     function.pop("parameters", None)
 
+                # 清理函数中的不支持字段
+                function = _clean_json_schema_properties(function)
                 function_declarations.append(function)
 
         if function_declarations:

--- a/app/service/chat/vertex_express_chat_service.py
+++ b/app/service/chat/vertex_express_chat_service.py
@@ -28,6 +28,33 @@ def _has_image_parts(contents: List[Dict[str, Any]]) -> bool:
     return False
 
 
+def _clean_json_schema_properties(obj: Any) -> Any:
+    """清理JSON Schema中Gemini API不支持的字段"""
+    if not isinstance(obj, dict):
+        return obj
+    
+    # Gemini API不支持的JSON Schema字段
+    unsupported_fields = {
+        "exclusiveMaximum", "exclusiveMinimum", "const", "examples", 
+        "contentEncoding", "contentMediaType", "if", "then", "else",
+        "allOf", "anyOf", "oneOf", "not", "definitions", "$schema",
+        "$id", "$ref", "$comment", "readOnly", "writeOnly"
+    }
+    
+    cleaned = {}
+    for key, value in obj.items():
+        if key in unsupported_fields:
+            continue
+        if isinstance(value, dict):
+            cleaned[key] = _clean_json_schema_properties(value)
+        elif isinstance(value, list):
+            cleaned[key] = [_clean_json_schema_properties(item) for item in value]
+        else:
+            cleaned[key] = value
+    
+    return cleaned
+
+
 def _build_tools(model: str, payload: Dict[str, Any]) -> List[Dict[str, Any]]:
     """构建工具"""
     
@@ -40,7 +67,15 @@ def _build_tools(model: str, payload: Dict[str, Any]) -> List[Dict[str, Any]]:
             for k, v in item.items():
                 if k == "functionDeclarations" and v and isinstance(v, list):
                     functions = record.get("functionDeclarations", [])
-                    functions.extend(v)
+                    # 清理每个函数声明中的不支持字段
+                    cleaned_functions = []
+                    for func in v:
+                        if isinstance(func, dict):
+                            cleaned_func = _clean_json_schema_properties(func)
+                            cleaned_functions.append(cleaned_func)
+                        else:
+                            cleaned_functions.append(func)
+                    functions.extend(cleaned_functions)
                     record["functionDeclarations"] = functions
                 else:
                     record[k] = v


### PR DESCRIPTION
### 🐛 问题描述
Claude Code Router 项目结合 `Claude Code （MacOS）` 在调用本项目接口时出现以下错误：
- API调用失败，状态码400，提示"Unknown name exclusiveMaximum/exclusiveMinimum"
- generationConfig相关的配置处理问题 (`API Error (500 {"error":{"message":"Error from provider: {\"error\":{\"code\":\"http_error\",\"message\":\"Internal server error during gemini_generate_content\"}}","type":"api_error","code":"provider_response_error"}}) · Retrying in 1 seconds… (attempt 1/10)`)

### 🔧 修复内容

#### 1. 清理JSON Schema不支持字段
- **文件**: `app/service/chat/gemini_chat_service.py`, `app/service/chat/openai_chat_service.py`, `app/service/chat/vertex_express_chat_service.py`
- **问题**: Gemini API不支持某些JSON Schema标准字段，如`exclusiveMaximum`、`exclusiveMinimum`等
- **修复**: 
  - 新增`_clean_json_schema_properties`函数，过滤不支持的字段
  - 在处理`functionDeclarations`时自动清理这些字段
  - 支持的过滤字段包括：`exclusiveMaximum`, `exclusiveMinimum`, `const`, `examples`, `allOf`, `anyOf`, `oneOf`, `not`, `$schema`, `$id`, `$ref`等

#### 2. 修复generationConfig处理
- **文件**: `app/service/chat/gemini_chat_service.py`
- **问题**: `generationConfig`为None时可能导致API调用异常
- **修复**: 确保`generationConfig`不为None，提供默认空对象

### 🎯 影响范围
- 提升与Claude Code Router等第三方工具的兼容性
- 修复工具调用时的JSON Schema验证错误
- 不影响现有功能，向后兼容

### ✅ 测试
- [x] 修复Claude Code Router调用接口时的400错误
- [x] 确保现有工具调用功能正常
- [x] 验证三个聊天服务的一致性
