### PR TITLE
解决使用request.generationConfig后出现的'parts' 错误

### DIFF
--- a/.augment-guidelines
+++ b/.augment-guidelines
@@ -1,0 +1,2 @@
+修改代码前记得调用AugmentContextEngine对项目上下文进行了解。
+需要在虚拟环境启动项目

--- a/.augment-guidelines
+++ b/.augment-guidelines
@@ -1,2 +1,0 @@
-修改代码前记得调用AugmentContextEngine对项目上下文进行了解。
-需要在虚拟环境启动项目

--- a/app/service/chat/gemini_chat_service.py
+++ b/app/service/chat/gemini_chat_service.py
@@ -135,7 +135,7 @@ def _filter_empty_parts(contents: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
 def _build_payload(model: str, request: GeminiRequest) -> Dict[str, Any]:
     """构建请求payload"""
-    request_dict = request.model_dump()
+    request_dict = request.model_dump(by_alias=True, exclude_none=False)
     if request.generationConfig:
         if request.generationConfig.maxOutputTokens is None:
             # 如果未指定最大输出长度，则不传递该字段，解决截断的问题

--- a/app/service/chat/vertex_express_chat_service.py
+++ b/app/service/chat/vertex_express_chat_service.py
@@ -115,7 +115,7 @@ def _get_safety_settings(model: str) -> List[Dict[str, str]]:
 
 def _build_payload(model: str, request: GeminiRequest) -> Dict[str, Any]:
     """构建请求payload"""
-    request_dict = request.model_dump()
+    request_dict = request.model_dump(by_alias=True, exclude_none=False)
     if request.generationConfig:
         if request.generationConfig.maxOutputTokens is None:
             # 如果未指定最大输出长度，则不传递该字段，解决截断的问题

--- a/app/service/tts/native/tts_chat_service.py
+++ b/app/service/tts/native/tts_chat_service.py
@@ -69,7 +69,7 @@ class TTSGeminiChatService(GeminiChatService):
             # 构建TTS专用的payload - 不包含tools和safetySettings
             from app.service.chat.gemini_chat_service import _filter_empty_parts
 
-            request_dict = request.model_dump()
+            request_dict = request.model_dump(by_alias=True, exclude_none=False)
 
             # 构建TTS专用的简化payload
             payload = {
@@ -130,7 +130,7 @@ class TTSGeminiChatService(GeminiChatService):
                 error_type="tts-api-error",
                 error_log=error_msg,
                 error_code=status_code,
-                request_msg=request.model_dump()
+                request_msg=request.model_dump(by_alias=True, exclude_none=False)
             )
 
             logger.error(f"TTS API call failed: {error_msg}")


### PR DESCRIPTION
问题总结与解决方案
背景
根据您的反馈，我移除了 raw_request: Request 参数，改为直接从 request.generationConfig 获取TTS配置，以消除代码冗余。

遇到的问题：
修改后出现了 'parts' 相关的KeyError错误：

问题根因分析：
通过深入分析发现，问题出现在Pydantic模型的序列化过程中：

修改前：使用 raw_request.body() 获取原始JSON数据，保持了API期望的字段名格式
修改后：使用 request.model_dump() 获取数据，但默认情况下使用模型内部字段名而不是API别名
具体问题：

 GeminiRequest 模型中定义了字段别名：generationConfig: Optional[GenerationConfig] = Field(default=None, alias="generation_config")
model_dump() 默认使用内部字段名 generation_config，而Gemini API期望的是  generationConfig
这导致构建的payload格式与API期望不匹配，引发错误
解决方案
我修改了所有相关文件中的 model_dump() 调用，添加了正确的参数：

修改的文件：

 app/service/tts/native/tts_chat_service.py
 app/service/chat/gemini_chat_service.py
 app/service/chat/vertex_express_chat_service.py
具体修改：

参数说明：

by_alias=True：使用字段别名（如  generationConfig）而不是内部字段名
exclude_none=False：保留None值字段，确保数据结构完整

备注：tts以及文本请求均通过测试，并再次pull。