### PR TITLE
fix: 修复 JSON 响应格式与工具调用冲突的问题

### DIFF
--- a/app/service/chat/gemini_chat_service.py
+++ b/app/service/chat/gemini_chat_service.py
@@ -222,9 +222,9 @@ def _build_payload(model: str, request: GeminiRequest) -> Dict[str, Any]:
         }
         
         # 解决 "Tool use with a response mime type: 'application/json' is unsupported" 问题
-        # 如果存在tools字段或内容中包含函数调用，则移除 responseMimeType
-        # 注意：即使tools为空数组，Gemini API也不支持同时使用tools和responseMimeType
-        has_tools_field = tools is not None
+        # 如果存在非空tools字段或内容中包含函数调用，则移除 responseMimeType
+        # 注意：只有当tools数组包含实际工具定义时，Gemini API才不支持同时使用tools和responseMimeType
+        has_tools_field = tools is not None and len(tools) > 0
         has_function_call = any(
             part.get("functionCall")
             for content in payload.get("contents", [])
@@ -319,13 +319,6 @@ class GeminiChatService:
             else:
                 logger.warning(f"No API key found for file {file_names[0]}, using default key: {redact_key_for_logging(api_key)}")
         
-        # 检查是否请求 JSON 响应格式且无工具调用
-        is_json_response_requested = (
-            request.generationConfig and 
-            getattr(request.generationConfig, 'responseMimeType', None) == 'application/json' and
-            not request.tools
-        )
-        
         payload = _build_payload(model, request)
         start_time = time.perf_counter()
         request_datetime = datetime.datetime.now()
@@ -337,12 +330,6 @@ class GeminiChatService:
             response = await self.api_client.generate_content(payload, model, api_key)
             is_success = True
             status_code = 200
-            
-            # 如果请求的是 JSON 格式且无工具调用，直接返回原始响应
-            if is_json_response_requested:
-                logger.info("Returning raw JSON response as requested")
-                return response
-            
             return self.response_handler.handle_response(response, model, stream=False)
         except Exception as e:
             is_success = False

--- a/app/service/chat/openai_chat_service.py
+++ b/app/service/chat/openai_chat_service.py
@@ -226,10 +226,10 @@ def _build_payload(
         payload["systemInstruction"] = instruction
 
     # 解决 "Tool use with a response mime type: 'application/json' is unsupported" 问题
-    # 检查是否存在tools字段或内容中包含函数调用
-    # 注意：即使tools为空数组，Gemini API也不支持同时使用tools和responseMimeType
+    # 检查是否存在非空tools字段或内容中包含函数调用
+    # 注意：只有当tools数组包含实际工具定义时，Gemini API才不支持同时使用tools和responseMimeType
     tools = payload.get("tools", [])
-    has_tools_field = tools is not None
+    has_tools_field = tools is not None and len(tools) > 0
     has_function_call = any(
         message.get("tool_calls") or  # OpenAI format
         any(part.get("functionCall") for part in message.get("parts", []) if isinstance(part, dict))  # Gemini format

--- a/app/service/chat/vertex_express_chat_service.py
+++ b/app/service/chat/vertex_express_chat_service.py
@@ -190,6 +190,23 @@ def _build_payload(model: str, request: GeminiRequest) -> Dict[str, Any]:
             else:
                 payload["generationConfig"]["thinkingConfig"] = {"thinkingBudget": settings.THINKING_BUDGET_MAP.get(model,1000)}
 
+    # 解决 "Tool use with a response mime type: 'application/json' is unsupported" 问题
+    # 检查是否存在tools字段或内容中包含函数调用
+    # 注意：即使tools为空数组，Gemini API也不支持同时使用tools和responseMimeType
+    tools = payload.get("tools", [])
+    has_tools_field = tools is not None
+    has_function_call = any(
+        part.get("functionCall")
+        for content in payload.get("contents", [])
+        for part in content.get("parts", [])
+        if isinstance(part, dict)
+    )
+    
+    if (has_tools_field or has_function_call) and payload.get("generationConfig"):
+        if "responseMimeType" in payload["generationConfig"]:
+            payload["generationConfig"].pop("responseMimeType", None)
+            logger.info("Removed responseMimeType due to tool usage conflict")
+
     return payload
 
 
@@ -229,6 +246,13 @@ class GeminiChatService:
         self, model: str, request: GeminiRequest, api_key: str
     ) -> Dict[str, Any]:
         """生成内容"""
+        # 检查是否请求 JSON 响应格式且无工具调用
+        is_json_response_requested = (
+            request.generationConfig and 
+            getattr(request.generationConfig, 'responseMimeType', None) == 'application/json' and
+            not request.tools
+        )
+        
         payload = _build_payload(model, request)
         start_time = time.perf_counter()
         request_datetime = datetime.datetime.now()
@@ -240,6 +264,12 @@ class GeminiChatService:
             response = await self.api_client.generate_content(payload, model, api_key)
             is_success = True
             status_code = 200
+            
+            # 如果请求的是 JSON 格式且无工具调用，直接返回原始响应
+            if is_json_response_requested:
+                logger.info("Returning raw JSON response as requested")
+                return response
+            
             return self.response_handler.handle_response(response, model, stream=False)
         except Exception as e:
             is_success = False

--- a/app/service/chat/vertex_express_chat_service.py
+++ b/app/service/chat/vertex_express_chat_service.py
@@ -191,10 +191,10 @@ def _build_payload(model: str, request: GeminiRequest) -> Dict[str, Any]:
                 payload["generationConfig"]["thinkingConfig"] = {"thinkingBudget": settings.THINKING_BUDGET_MAP.get(model,1000)}
 
     # 解决 "Tool use with a response mime type: 'application/json' is unsupported" 问题
-    # 检查是否存在tools字段或内容中包含函数调用
-    # 注意：即使tools为空数组，Gemini API也不支持同时使用tools和responseMimeType
+    # 检查是否存在非空tools字段或内容中包含函数调用
+    # 注意：只有当tools数组包含实际工具定义时，Gemini API才不支持同时使用tools和responseMimeType
     tools = payload.get("tools", [])
-    has_tools_field = tools is not None
+    has_tools_field = tools is not None and len(tools) > 0
     has_function_call = any(
         part.get("functionCall")
         for content in payload.get("contents", [])
@@ -246,13 +246,6 @@ class GeminiChatService:
         self, model: str, request: GeminiRequest, api_key: str
     ) -> Dict[str, Any]:
         """生成内容"""
-        # 检查是否请求 JSON 响应格式且无工具调用
-        is_json_response_requested = (
-            request.generationConfig and 
-            getattr(request.generationConfig, 'responseMimeType', None) == 'application/json' and
-            not request.tools
-        )
-        
         payload = _build_payload(model, request)
         start_time = time.perf_counter()
         request_datetime = datetime.datetime.now()
@@ -264,12 +257,6 @@ class GeminiChatService:
             response = await self.api_client.generate_content(payload, model, api_key)
             is_success = True
             status_code = 200
-            
-            # 如果请求的是 JSON 格式且无工具调用，直接返回原始响应
-            if is_json_response_requested:
-                logger.info("Returning raw JSON response as requested")
-                return response
-            
             return self.response_handler.handle_response(response, model, stream=False)
         except Exception as e:
             is_success = False


### PR DESCRIPTION
- 解决当 responseMimeType 设置为 'application/json' 且启用工具调用时出现的冲突
- 在检测到工具调用时自动移除 responseMimeType 以避免 API 错误
- 修复涉及三个聊天服务：gemini_chat_service、openai_chat_service、vertex_express_chat_service
- 解决 GitHub issue #264: "Tool use with a response mime type: 'application/json' is unsupported"