### PR TITLE
Implement base64 fallback for image handling when no uploader is configured

### DIFF
--- a/app/service/image/image_create_service.py
+++ b/app/service/image/image_create_service.py
@@ -10,6 +10,7 @@ from app.core.constants import VALID_IMAGE_RATIOS
 from app.domain.openai_models import ImageGenerationRequest
 from app.log.logger import get_image_create_logger
 from app.utils.uploader import ImageUploaderFactory
+from app.utils.helpers import is_image_upload_configured
 
 logger = get_image_create_logger()
 
@@ -97,12 +98,15 @@ class ImageCreateService:
                 image_data = generated_image.image.image_bytes
                 image_uploader = None
 
-                if request.response_format == "b64_json":
+                # Return base64 if explicitly requested or if no uploader is configured
+                if request.response_format == "b64_json" or not is_image_upload_configured():
                     base64_image = base64.b64encode(image_data).decode("utf-8")
                     images_data.append(
                         {"b64_json": base64_image, "revised_prompt": request.prompt}
                     )
+                    continue
                 else:
+                    # Upload to configured provider
                     current_date = time.strftime("%Y/%m/%d")
                     filename = f"{current_date}/{uuid.uuid4().hex[:8]}.png"
 

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -207,6 +207,5 @@ def is_image_upload_configured() -> bool:
         return all([
             getattr(settings, "CLOUDFLARE_IMGBED_URL", ""),
             getattr(settings, "CLOUDFLARE_IMGBED_AUTH_CODE", ""),
-            getattr(settings, "CLOUDFLARE_IMGBED_UPLOAD_FOLDER", ""),
         ])
     return False

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import logging
 
 from app.core.constants import DATA_URL_PATTERN, IMAGE_URL_PATTERN, VALID_IMAGE_RATIOS
+from app.config.config import settings
 
 helper_logger = logging.getLogger("app.utils")
 
@@ -189,3 +190,19 @@ def get_current_version(default_version: str = "0.0.0") -> str:
     except IOError as e:
         helper_logger.error(f"Error reading VERSION file ('{version_file}'): {e}. Using default version '{default_version}'.")
         return default_version
+
+
+def is_image_upload_configured() -> bool:
+    """Return True only if a valid upload provider is selected and all required settings for that provider are present."""
+    provider = getattr(settings, "UPLOAD_PROVIDER", "").strip().lower()
+    if provider == "smms":
+        return bool(getattr(settings, "SMMS_SECRET_TOKEN", None))
+    if provider == "picgo":
+        return bool(getattr(settings, "PICGO_API_KEY", None))
+    if provider == "cloudflare_imgbed":
+        return all([
+            getattr(settings, "CLOUDFLARE_IMGBED_URL", None),
+            getattr(settings, "CLOUDFLARE_IMGBED_AUTH_CODE", None),
+            getattr(settings, "CLOUDFLARE_IMGBED_UPLOAD_FOLDER", None),
+        ])
+    return False

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -10,7 +10,6 @@ from pathlib import Path
 import logging
 
 from app.core.constants import DATA_URL_PATTERN, IMAGE_URL_PATTERN, VALID_IMAGE_RATIOS
-from app.config.config import settings
 
 helper_logger = logging.getLogger("app.utils")
 
@@ -193,16 +192,21 @@ def get_current_version(default_version: str = "0.0.0") -> str:
 
 
 def is_image_upload_configured() -> bool:
-    """Return True only if a valid upload provider is selected and all required settings for that provider are present."""
-    provider = getattr(settings, "UPLOAD_PROVIDER", "").strip().lower()
+    """Return True only if a valid upload provider is selected and all required settings for that provider are present. Uses lazy import to avoid circular imports."""
+    try:
+        from app.config.config import settings  # local import to avoid circular dependency at module import time
+    except Exception:
+        return False
+
+    provider = (getattr(settings, "UPLOAD_PROVIDER", "") or "").strip().lower()
     if provider == "smms":
-        return bool(getattr(settings, "SMMS_SECRET_TOKEN", None))
+        return bool(getattr(settings, "SMMS_SECRET_TOKEN", ""))
     if provider == "picgo":
-        return bool(getattr(settings, "PICGO_API_KEY", None))
+        return bool(getattr(settings, "PICGO_API_KEY", ""))
     if provider == "cloudflare_imgbed":
         return all([
-            getattr(settings, "CLOUDFLARE_IMGBED_URL", None),
-            getattr(settings, "CLOUDFLARE_IMGBED_AUTH_CODE", None),
-            getattr(settings, "CLOUDFLARE_IMGBED_UPLOAD_FOLDER", None),
+            getattr(settings, "CLOUDFLARE_IMGBED_URL", ""),
+            getattr(settings, "CLOUDFLARE_IMGBED_AUTH_CODE", ""),
+            getattr(settings, "CLOUDFLARE_IMGBED_UPLOAD_FOLDER", ""),
         ])
     return False


### PR DESCRIPTION
**目标**：当未配置任何图床（或配置不完整时），直接把模型返回的图片以 Gemini 官方格式透传给前端（含 inlineData 的 base64），即` data: {..."inlineData":{"mimeType":"image/png","data":"..."}} `结构；若配置了图床，则沿用当前上传->返回 Markdown 图片链接的逻辑。

**改动点**：
- 增加一个统一的“是否已配置图床”判断工具函数。
- 在 image 生成服务中，如果没配置图床，优先返回 base64（b64_json）而不是 URL。
- 在解析 Gemini 回复时（含图片的 inlineData），如果没配置图床，绕过“上传并替换成 Markdown”的逻辑，直接透传原始 Gemini 响应结构给客户端（从而客户端收到的仍是 data: {... inlineData ...}）。

- Close #338