### PR TITLE
Security problem fix

### DIFF
--- a/app/config/config.py
+++ b/app/config/config.py
@@ -158,9 +158,9 @@ class Settings(BaseSettings):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        # 设置默认AUTH_TOKEN（如果未提供）
-        if not self.AUTH_TOKEN and self.ALLOWED_TOKENS:
-            self.AUTH_TOKEN = self.ALLOWED_TOKENS[0]
+        # 安全修复：不再将 AUTH_TOKEN 默认回退为 ALLOWED_TOKENS[0]。
+        # AUTH_TOKEN 是管理员凭证，必须显式设置。
+        # 如果未设置 AUTH_TOKEN，管理面板将无法访问。
 
 
 # 创建全局配置实例


### PR DESCRIPTION
### 漏洞 1：Gemini 管理路由完全无需认证

中间件在 `middleware.py:29` 中对所有 `/gemini` 开头的路径跳过了身份验证：

```python
and not request.url.path.startswith("/gemini")
```

而以下 5 个管理路由注册在 `/gemini/v1beta` 前缀下，且没有任何路由级别的认证依赖，导致**任何人无需任何凭证即可直接访问**：

| 端点 | 风险 |
|------|------|
| `POST /gemini/v1beta/reset-all-fail-counts` | 重置所有 API 密钥的失败计数 |
| `POST /gemini/v1beta/reset-selected-fail-counts` | 批量重置指定密钥的失败计数 |
| `POST /gemini/v1beta/reset-fail-count/{api_key}` | 重置单个密钥的失败计数 |
| `POST /gemini/v1beta/verify-key/{api_key}` | 验证 API 密钥有效性（可被用作密钥验证预言机） |
| `POST /gemini/v1beta/verify-selected-keys` | 批量验证多个 API 密钥 |

### 漏洞 2：AUTH_TOKEN 默认回退为 ALLOWED_TOKENS[0]

当未显式设置 `AUTH_TOKEN` 时，`config.py` 中的 `__init__` 会将其静默设置为 `ALLOWED_TOKENS[0]`，导致任何普通 API 用户自动拥有管理员权限。

## 修复方案

### 修复 1：为管理路由添加 Cookie 认证

在 `gemini_routes.py` 中新增 `verify_admin_cookie()` 依赖函数，从 Cookie 中验证管理员身份令牌，并将其添加到所有 5 个管理路由上。

前端无需修改——`fetch()` 对同源请求默认携带 Cookie，管理面板页面本身已需要 Cookie 认证才能访问，因此 `auth_token` Cookie 会自动随请求发送。

### 修复 2：移除 AUTH_TOKEN 自动回退逻辑

移除 `config.py` 中将 `AUTH_TOKEN` 静默回退为 `ALLOWED_TOKENS[0]` 的代码。`AUTH_TOKEN` 作为管理员凭证必须显式设置。

## 变更文件

- `app/router/gemini_routes.py` — 新增 `verify_admin_cookie()` 依赖，5 个管理路由添加认证
- `app/config/config.py` — 移除 `AUTH_TOKEN` 回退到 `ALLOWED_TOKENS[0]` 的逻辑

## ⚠️ 破坏性变更

之前未显式设置 `AUTH_TOKEN` 的用户，升级后需要在 `.env` 文件中添加：

```env
AUTH_TOKEN=你的管理员令牌
```

否则管理面板将无法访问。这是有意为之的安全改进。