### PR TITLE
feat: support Gemini authorization API keys

### DIFF
--- a/app/log/logger.py
+++ b/app/log/logger.py
@@ -45,6 +45,7 @@ class AccessLogFormatter(logging.Formatter):
     # API key patterns to match in URLs
     API_KEY_PATTERNS = [
         r"\bAIza[0-9A-Za-z_-]{35}",  # Google API keys (like Gemini)
+        r"(?<![0-9A-Za-z_-])AQ\.[0-9A-Za-z_-]{50}(?![0-9A-Za-z_-])",  # Gemini auth keys
         r"\bsk-[0-9A-Za-z_-]{20,}",  # OpenAI and general sk- prefixed keys
     ]
 
@@ -322,6 +323,7 @@ def setup_access_logging():
 
     Supported API key formats:
     - Google/Gemini API keys: AIza[35 chars]
+    - Google/Gemini authorization keys: AQ.[50 chars]
     - OpenAI API keys: sk-[48 chars]
     - General sk- prefixed keys: sk-[20+ chars]
 

--- a/app/router/routes.py
+++ b/app/router/routes.py
@@ -70,7 +70,11 @@ def setup_page_routes(app: FastAPI) -> None:
     @app.get("/", response_class=HTMLResponse)
     async def auth_page(request: Request):
         """认证页面"""
-        return templates.TemplateResponse("auth.html", {"request": request})
+        return templates.TemplateResponse(
+            request=request,
+            name="auth.html",
+            context={"request": request},
+        )
 
     @app.post("/auth")
     async def authenticate(request: Request):
@@ -121,8 +125,9 @@ def setup_page_routes(app: FastAPI) -> None:
 
             logger.info(f"Keys status retrieved successfully. Total keys: {total_keys}")
             return templates.TemplateResponse(
-                "keys_status.html",
-                {
+                request=request,
+                name="keys_status.html",
+                context={
                     "request": request,
                     "valid_keys": {},
                     "invalid_keys": {},
@@ -137,8 +142,9 @@ def setup_page_routes(app: FastAPI) -> None:
             # Even if there's an error, render the page with whatever data is available
             # or with empty/default values, so the frontend can still load.
             return templates.TemplateResponse(
-                "keys_status.html",
-                {
+                request=request,
+                name="keys_status.html",
+                context={
                     "request": request,
                     "valid_keys": {},
                     "invalid_keys": {},
@@ -165,7 +171,9 @@ def setup_page_routes(app: FastAPI) -> None:
 
             logger.info("Config page accessed successfully")
             return templates.TemplateResponse(
-                "config_editor.html", {"request": request}
+                request=request,
+                name="config_editor.html",
+                context={"request": request},
             )
         except Exception as e:
             logger.error(f"Error accessing config page: {str(e)}")
@@ -181,7 +189,11 @@ def setup_page_routes(app: FastAPI) -> None:
                 return RedirectResponse(url="/", status_code=302)
 
             logger.info("Logs page accessed successfully")
-            return templates.TemplateResponse("error_logs.html", {"request": request})
+            return templates.TemplateResponse(
+                request=request,
+                name="error_logs.html",
+                context={"request": request},
+            )
         except Exception as e:
             logger.error(f"Error accessing logs page: {str(e)}")
             raise

--- a/app/service/client/api_client.py
+++ b/app/service/client/api_client.py
@@ -47,11 +47,15 @@ class GeminiApiClient(ApiClient):
             model = model[:-20]
         return model
 
-    def _prepare_headers(self) -> Dict[str, str]:
+    def _prepare_headers(self, api_key: str) -> Dict[str, str]:
         headers = {}
         if settings.CUSTOM_HEADERS:
             headers.update(settings.CUSTOM_HEADERS)
-            logger.info(f"Using custom headers: {settings.CUSTOM_HEADERS}")
+            logger.info("Using configured custom headers")
+        # Google documents this header for both standard and authorization keys.
+        # Set it last so a stale CUSTOM_HEADERS value cannot override the selected
+        # key from the key manager.
+        headers["x-goog-api-key"] = api_key
         return headers
 
     async def get_models(self, api_key: str) -> Optional[Dict[str, Any]]:
@@ -66,9 +70,9 @@ class GeminiApiClient(ApiClient):
                 proxy_to_use = random.choice(settings.PROXIES)
             logger.info(f"Using proxy for getting models: {proxy_to_use}")
 
-        headers = self._prepare_headers()
+        headers = self._prepare_headers(api_key)
         async with httpx.AsyncClient(timeout=timeout, proxy=proxy_to_use) as client:
-            url = f"{self.base_url}/models?key={api_key}&pageSize=1000"
+            url = f"{self.base_url}/models?pageSize=1000"
             try:
                 response = await client.get(url, headers=headers)
                 response.raise_for_status()
@@ -95,10 +99,10 @@ class GeminiApiClient(ApiClient):
                 proxy_to_use = random.choice(settings.PROXIES)
             logger.info(f"Using proxy for getting models: {proxy_to_use}")
 
-        headers = self._prepare_headers()
+        headers = self._prepare_headers(api_key)
 
         async with httpx.AsyncClient(timeout=timeout, proxy=proxy_to_use) as client:
-            url = f"{self.base_url}/models/{model}:generateContent?key={api_key}"
+            url = f"{self.base_url}/models/{model}:generateContent"
             response = await client.post(url, json=payload, headers=headers)
 
             if response.status_code != 200:
@@ -129,9 +133,9 @@ class GeminiApiClient(ApiClient):
                 proxy_to_use = random.choice(settings.PROXIES)
             logger.info(f"Using proxy for getting models: {proxy_to_use}")
 
-        headers = self._prepare_headers()
+        headers = self._prepare_headers(api_key)
         async with httpx.AsyncClient(timeout=timeout, proxy=proxy_to_use) as client:
-            url = f"{self.base_url}/models/{model}:streamGenerateContent?alt=sse&key={api_key}"
+            url = f"{self.base_url}/models/{model}:streamGenerateContent?alt=sse"
             async with client.stream(
                 method="POST", url=url, json=payload, headers=headers
             ) as response:
@@ -156,9 +160,9 @@ class GeminiApiClient(ApiClient):
                 proxy_to_use = random.choice(settings.PROXIES)
             logger.info(f"Using proxy for counting tokens: {proxy_to_use}")
 
-        headers = self._prepare_headers()
+        headers = self._prepare_headers(api_key)
         async with httpx.AsyncClient(timeout=timeout, proxy=proxy_to_use) as client:
-            url = f"{self.base_url}/models/{model}:countTokens?key={api_key}"
+            url = f"{self.base_url}/models/{model}:countTokens"
             response = await client.post(url, json=payload, headers=headers)
             if response.status_code != 200:
                 error_content = response.text
@@ -180,9 +184,9 @@ class GeminiApiClient(ApiClient):
                 proxy_to_use = random.choice(settings.PROXIES)
             logger.info(f"Using proxy for embedding: {proxy_to_use}")
 
-        headers = self._prepare_headers()
+        headers = self._prepare_headers(api_key)
         async with httpx.AsyncClient(timeout=timeout, proxy=proxy_to_use) as client:
-            url = f"{self.base_url}/models/{model}:embedContent?key={api_key}"
+            url = f"{self.base_url}/models/{model}:embedContent"
             response = await client.post(url, json=payload, headers=headers)
             if response.status_code != 200:
                 error_content = response.text
@@ -207,9 +211,9 @@ class GeminiApiClient(ApiClient):
                 proxy_to_use = random.choice(settings.PROXIES)
             logger.info(f"Using proxy for batch embedding: {proxy_to_use}")
 
-        headers = self._prepare_headers()
+        headers = self._prepare_headers(api_key)
         async with httpx.AsyncClient(timeout=timeout, proxy=proxy_to_use) as client:
-            url = f"{self.base_url}/models/{model}:batchEmbedContents?key={api_key}"
+            url = f"{self.base_url}/models/{model}:batchEmbedContents"
             response = await client.post(url, json=payload, headers=headers)
             if response.status_code != 200:
                 error_content = response.text

--- a/app/service/files/files_service.py
+++ b/app/service/files/files_service.py
@@ -73,6 +73,7 @@ class FilesService:
                     "X-Goog-Upload-Protocol": headers.get("x-goog-upload-protocol", "resumable"),
                     "X-Goog-Upload-Command": headers.get("x-goog-upload-command", "start"),
                     "Content-Type": headers.get("content-type", "application/json"),
+                    "X-Goog-Api-Key": api_key,
                 }
                 
                 # 添加其他必要的头
@@ -86,7 +87,6 @@ class FilesService:
                     "https://generativelanguage.googleapis.com/upload/v1beta/files",
                     headers=forward_headers,
                     content=body,
-                    params={"key": api_key}
                 )
                 
                 if response.status_code != 200:
@@ -253,7 +253,7 @@ class FilesService:
             async with AsyncClient() as client:
                 response = await client.get(
                     f"{settings.BASE_URL}/{file_name}",
-                    params={"key": api_key}
+                    headers={"X-Goog-Api-Key": api_key},
                 )
                 
                 if response.status_code != 200:
@@ -382,7 +382,7 @@ class FilesService:
             async with AsyncClient() as client:
                 response = await client.delete(
                     f"{settings.BASE_URL}/{file_name}",
-                    params={"key": api_key}
+                    headers={"X-Goog-Api-Key": api_key},
                 )
                 
                 if response.status_code not in [200, 204]:
@@ -421,7 +421,7 @@ class FilesService:
             async with AsyncClient() as client:
                 response = await client.get(
                     f"{settings.BASE_URL}/{file_name}",
-                    params={"key": api_key}
+                    headers={"X-Goog-Api-Key": api_key},
                 )
                 
                 if response.status_code != 200:
@@ -474,7 +474,7 @@ class FilesService:
                     async with AsyncClient() as client:
                         await client.delete(
                             f"{settings.BASE_URL}/{file_name}",
-                            params={"key": api_key}
+                            headers={"X-Goog-Api-Key": api_key},
                         )
                 except Exception as e:
                     # 记录错误但继续处理其他文件

--- a/app/static/js/config_editor.js
+++ b/app/static/js/config_editor.js
@@ -10,7 +10,9 @@ const CUSTOM_HEADER_KEY_INPUT_CLASS = "custom-header-key-input";
 const CUSTOM_HEADER_VALUE_INPUT_CLASS = "custom-header-value-input";
 const SAFETY_SETTING_ITEM_CLASS = "safety-setting-item";
 const SHOW_CLASS = "show"; // For modals
-const API_KEY_REGEX = /AIzaSy\S{33}/g;
+// Gemini supports legacy standard keys (AIza...) and service-account-bound
+// authorization keys (AQ....).
+const API_KEY_REGEX = /(?:AIzaSy[A-Za-z0-9_-]{33}|AQ\.[A-Za-z0-9_-]{50})/g;
 const PROXY_REGEX =
   /(?:https?|socks5):\/\/(?:[^:@\/]+(?::[^@\/]+)?@)?(?:[^:\/\s]+)(?::\d+)?/g;
 const VERTEX_API_KEY_REGEX = /AQ\.[a-zA-Z0-9_\-]{50}/g; // 新增 Vertex Express API Key 正则

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -149,9 +149,15 @@ def is_valid_api_key(key: str) -> bool:
     Returns:
         bool: 如果密钥格式有效则返回True
     """
-    # 检查Gemini API密钥格式
-    if key.startswith("AIza"):
-        return len(key) >= 30
+    if not isinstance(key, str):
+        return False
+
+    # Gemini standard keys are 39 characters; authorization keys are 53
+    # characters and use the AQ. prefix.
+    if re.fullmatch(r"AIzaSy[A-Za-z0-9_-]{33}", key):
+        return True
+    if re.fullmatch(r"AQ\.[A-Za-z0-9_-]{50}", key):
+        return True
 
     # 检查OpenAI API密钥格式
     if key.startswith("sk-"):
@@ -170,13 +176,12 @@ def redact_key_for_logging(key: str) -> str:
     Returns:
         str: Redacted key in format "first6...last6" or descriptive placeholder for edge cases
     """
-    if not key:
-        return key
+    if not isinstance(key, str) or not key:
+        return "[INVALID_KEY]"
 
     if len(key) <= 12:
-        return f"{key[:3]}...{key[-3:]}"
-    else:
-        return f"{key[:6]}...{key[-6:]}"
+        return "[SHORT_KEY]"
+    return f"{key[:6]}...{key[-6:]}"
 
 
 def get_current_version(default_version: str = "0.0.0") -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-fastapi
+fastapi==0.138.0
 httpx[socks]
 openai
 pydantic
 pydantic_settings
 requests
-starlette
+starlette==1.3.1
 uvicorn
 google-genai
 jinja2

--- a/tests/test_key_redaction.py
+++ b/tests/test_key_redaction.py
@@ -6,7 +6,9 @@ import unittest
 import logging
 from unittest.mock import patch, MagicMock
 
-from app.utils.helpers import redact_key_for_logging
+from app.config.config import settings
+from app.service.client.api_client import GeminiApiClient
+from app.utils.helpers import is_valid_api_key, redact_key_for_logging
 from app.log.logger import AccessLogFormatter
 
 
@@ -95,6 +97,14 @@ class TestAccessLogFormatter(unittest.TestCase):
         self.assertIn("AIzaSy...xDfGhI", result)
         self.assertNotIn("AIzaSyDhKGfJ8xYzQwErTyUiOpLkMnBvCxDfGhI", result)
 
+    def test_gemini_auth_key_redaction_in_url(self):
+        """Test redaction of service-account-bound Gemini auth keys."""
+        auth_key = "AQ." + "aB_9-" * 10
+        log_message = f'POST /verify-key/{auth_key} HTTP/1.1" 200'
+        result = self.formatter._redact_api_keys_in_message(log_message)
+        self.assertIn("AQ.aB_...-aB_9-", result)
+        self.assertNotIn(auth_key, result)
+
     def test_openai_key_redaction_in_url(self):
         """Test redaction of OpenAI API keys in URLs"""
         log_message = 'GET /api/models?key=sk-1234567890abcdef1234567890abcdef1234567890abcdef HTTP/1.1" 200'
@@ -162,7 +172,7 @@ class TestAccessLogFormatter(unittest.TestCase):
     def test_regex_patterns_compilation(self):
         """Test that regex patterns are properly compiled"""
         formatter = AccessLogFormatter()
-        self.assertEqual(len(formatter.compiled_patterns), 2)
+        self.assertEqual(len(formatter.compiled_patterns), 3)
         self.assertTrue(
             all(hasattr(pattern, "sub") for pattern in formatter.compiled_patterns)
         )
@@ -181,6 +191,31 @@ class TestAccessLogFormatter(unittest.TestCase):
             result = self.formatter._redact_api_keys_in_message(log_message)
             self.assertNotIn(test_key, result)
             self.assertIn("sk-", result)  # Should still contain the prefix
+
+
+class TestGeminiAuthKeys(unittest.TestCase):
+    """Compatibility tests for service-account-bound Gemini API keys."""
+
+    def test_accepts_standard_and_authorization_key_formats(self):
+        self.assertTrue(is_valid_api_key("AIzaSy" + "a" * 33))
+        self.assertTrue(is_valid_api_key("AQ." + "a" * 50))
+
+    def test_rejects_malformed_gemini_keys(self):
+        self.assertFalse(is_valid_api_key("AQ." + "a" * 49))
+        self.assertFalse(is_valid_api_key("AQ." + "a" * 51))
+        self.assertFalse(is_valid_api_key("AIzaSy" + "a" * 32))
+
+    def test_client_uses_selected_key_in_header(self):
+        client = GeminiApiClient(
+            "https://generativelanguage.googleapis.com/v1beta"
+        )
+        auth_key = "AQ." + "a" * 50
+        custom_headers = {"X-Test": "value", "x-goog-api-key": "stale"}
+        with patch.object(settings, "CUSTOM_HEADERS", custom_headers):
+            headers = client._prepare_headers(auth_key)
+
+        self.assertEqual(headers["x-goog-api-key"], auth_key)
+        self.assertEqual(headers["X-Test"], "value")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Accept both legacy `AIza...` keys and service-account-bound `AQ.` authorization keys in the configuration UI and backend validation.
- Send Gemini credentials through the documented `x-goog-api-key` header for model, generation, streaming, token-counting, embedding, and Files API requests.
- Redact `AQ.` keys from access logs and avoid logging custom header values.
- Use keyword arguments for `TemplateResponse` and pin the verified FastAPI/Starlette versions so source builds work with the current template API.
- Add coverage for authorization-key validation, header precedence, and log redaction.

## Context

Google AI Studio now creates authorization API keys by default. These keys use the `AQ.` format, while the current UI only extracts `AIza...` keys and outbound Gemini requests place credentials in the URL query string.

Google documentation: https://ai.google.dev/gemini-api/docs/api-key

## Compatibility

- Existing `AIza...` keys remain supported.
- `CUSTOM_HEADERS` are preserved, but the key selected by the key manager always wins for `x-goog-api-key`.
- No database migration is required.

## Testing

- `python -m unittest discover -s tests -v` — 18 tests passed.
- Built the Docker image from this branch.
- Smoke-tested `/`, `/keys`, `/config`, `/logs`, and `/health`; all returned HTTP 200.

An actual Gemini request was not made in the automated test suite because it would require a real API key.